### PR TITLE
Handle names correctly if they come as bytes

### DIFF
--- a/bleson/core/types.py
+++ b/bleson/core/types.py
@@ -399,7 +399,7 @@ class Advertisement(ValueObject):
 
     @name.setter
     def name(self, name):
-        if isinstance(name, bytearray):
+        if isinstance(name, bytearray) or isinstance(name, bytes):
             self._name = str(name,'ascii')  # TODO: is the name really UTF8 encoded according to the Core spec?
         else:
             self._name = str(name)  # unit8


### PR DESCRIPTION
I have two Homekit BLE devices here and for both the names are reported as bytes. This fixes it.