### PR TITLE
Don't reverse addresses, they are already in the expected order

### DIFF
--- a/bleson/core/hci/type_converters.py
+++ b/bleson/core/hci/type_converters.py
@@ -113,7 +113,7 @@ class AdvertisingDataConverters(object):
         # TODO: move these 2 LUTs to a better place
         gap_adv_type = ['ADV_IND', 'ADV_DIRECT_IND', 'ADV_SCAN_IND', 'ADV_NONCONN_IND', 'SCAN_RSP'][data[1]]
         gap_addr_type = ['PUBLIC', 'RANDOM', 'PUBLIC_IDENTITY', 'RANDOM_STATIC'][data[2]]
-        gap_addr = data[8:2:-1]
+        gap_addr = data[3:9]
         rssi = rssi_from_byte(data[-1])
 
 

--- a/bleson/providers/linux/linux_adapter.py
+++ b/bleson/providers/linux/linux_adapter.py
@@ -83,7 +83,7 @@ class BluetoothHCIAdapter(Adapter):
         # Just extract a few parts for now
         device_id = hci_dev_info[0]
         device_name = hci_dev_info[1].split(b'\0',1)[0]
-        bd_address = hci_dev_info[7:1:-1]
+        bd_address = hci_dev_info[2:8]
         return Device(address=BDAddress(bd_address), name=device_name)
 
 


### PR DESCRIPTION
Tested locally. Seems to work both for the addresses in HCI frames and the local device.