### PR TITLE
Fixed code formatting in advertiser example

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -37,21 +37,22 @@ Advertise the host as a Bluetooth LE device with the name `bleson`
 
     .. testcode:: Advertiser
 
-    from time import sleep
+        from time import sleep
 
-    from bleson import get_provider, Advertiser, Advertisement
+        from bleson import get_provider, Advertiser, Advertisement
 
-    adapter = get_provider().get_adapter()
+        adapter = get_provider().get_adapter()
 
-    advertiser = Advertiser(adapter)
-    advertisement = Advertisement()
-    advertisement.name = "bleson"
+        advertiser = Advertiser(adapter)
+        advertisement = Advertisement()
+        advertisement.name = "bleson"
 
-    advertiser.advertisement = advertisement
+        advertiser.advertisement = advertisement
 
-    advertiser.start()
-    sleep(10)
-    advertiser.stop()
+        advertiser.start()
+        sleep(10)
+        advertiser.stop()
+
 
 Peripheral example
 ------------------


### PR DESCRIPTION
Currently, it is rendered like this. 

<img width="1228" alt="Screenshot 2020-09-02 at 10 13 04 PM" src="https://user-images.githubusercontent.com/4463796/92012031-89f36480-ed69-11ea-9521-677904ed34e2.png">
